### PR TITLE
fix bug with typo in the comparison of inter and intra distance density

### DIFF
--- a/R/pcrslayer.R
+++ b/R/pcrslayer.R
@@ -373,7 +373,7 @@ pcr_threshold_estimate <- function(wthn.btwn, thresh.method = "intersect") {
   dinter.mode <- ddinter$x[which.max(ddinter$y)]
 
   if (thresh.method == "intersect") {
-    p <- which(ddintra$y - ddinter$y > 0 & ddinter$y > dintra.mode)
+    p <- which(ddintra$y - ddinter$y > 0 & ddinter$x > dintra.mode)
     out <- ddinter$x[p[length(p)]]
   } else {
     out <- dinter.mode


### PR DESCRIPTION
close issue #22 

I replace the line :
 p <- which(ddintra$y - ddinter$y > 0 & ddinter$y > dintra.mode)
by : 
 p <- which(ddintra$y - ddinter$y > 0 & ddinter$x > dintra.mode)

now the comparison is correct.