### PR TITLE
hot fix bug travis dependence install (harfbuzz fribidi)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: r
 cache: packages
 
 before_install:
+  - sudo apt-get -y install libharfbuzz-dev libfribidi-dev
   - chmod +x ./travis-config.sh && ./travis-config.sh
 
 after_success:


### PR DESCRIPTION
install the dependence library libharfbuzz-dev libfribidi-dev to run a success integration.