### PR TITLE
fix bug in silva_annotator due to false paths in tax_slv_ssu_138.1.txt

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -29,7 +29,7 @@ Description: A comprehensive suite of tools to effectively curate DNA metabarcod
 License: GPL (>= 2)
 Encoding: UTF-8
 LazyData: true
-RoxygenNote: 7.1.1
+RoxygenNote: 7.2.0
 URL: https://github.com/metabaRfactory/metabaR
 Imports: ggplot2, vegan, reshape2, ade4, cowplot, seqinr, igraph, biomformat
 Depends: R (>= 2.10)
@@ -40,4 +40,3 @@ Suggests: knitr,
     pkgdown
 VignetteBuilder: knitr
 BugReports: https://github.com/metabaRfactory/metabaR/issues
-

--- a/R/silva_annotator.R
+++ b/R/silva_annotator.R
@@ -77,6 +77,14 @@ silva_annotator <- function(metabarlist, silva.path, clust.path, taxonomy.path) 
     silva <- read.csv(silva.path, header = T, sep = "\t", skip = 1, row.names = NULL)
     colnames(silva) <- c(colnames(silva)[-c(1, ncol(silva))], "classif_ncbi", "classif_silva")
 
+    # in SILVA 138.1, there are false paths:
+    #Eukaryota;Amorphea;Amoebozoa;SAR;Stramenopiles;
+    #Eukaryota;Amorphea;Amoebozoa;SAR;Stramenopiles;Labyrinthulomycetes;
+    #Eukaryota;Amorphea;Amoebozoa;SAR;Stramenopiles;Labyrinthulomycetes;Sorodiplophrys;
+
+    # so modify paths from xxx—ssu—otus.csv:
+    silva$classif_silva <- sub(pattern = "Eukaryota;Amorphea;Amoebozoa;SAR;Stramenopiles;", replacement = "Eukaryota;SAR;Stramenopiles;", silva$classif_silva)
+
     # taxo results formating
     tmp <- sapply(strsplit(as.vector(silva$classif_silva), "\\|"), function(x) x[4])
 
@@ -107,6 +115,11 @@ silva_annotator <- function(metabarlist, silva.path, clust.path, taxonomy.path) 
     #load old version (incomplete)
 
     taxonomy <- read.csv(taxonomy.path, header = F, sep = "\t", row.names = NULL, stringsAsFactors = FALSE)
+
+    # delete line with Eukaryota;Amorphea;Amoebozoa;SAR;Stramenopiles; change other paths in taxonomy:
+    taxonomy <- taxonomy[grep("Eukaryota;Amorphea;Amoebozoa;SAR;Stramenopiles;$", taxonomy$V1, invert = TRUE),]
+    taxonomy$V1 <- sub(pattern = "Eukaryota;Amorphea;Amoebozoa;SAR;Stramenopiles;", replacement = "Eukaryota;SAR;Stramenopiles;", taxonomy$V1)
+
     taxonomy$V3 <- gsub("superkingdom", "superkingdom2", taxonomy$V3, fixed=T)
     taxonomy$V3 <- gsub("domain", "superkingdom", taxonomy$V3, fixed=T)
     taxonomy$V3 <- gsub("major_clade", "superkingdom3", taxonomy$V3, fixed=T)

--- a/man/ggpcrplate.Rd
+++ b/man/ggpcrplate.Rd
@@ -7,7 +7,9 @@
 ggpcrplate(
   metabarlist,
   legend_title = "well_values",
-  FUN = function(metabarlist) {     rowSums(metabarlist$reads) }
+  FUN = function(metabarlist) {
+     rowSums(metabarlist$reads)
+ }
 )
 }
 \arguments{

--- a/man/ggpcrtag.Rd
+++ b/man/ggpcrtag.Rd
@@ -7,7 +7,9 @@
 ggpcrtag(
   metabarlist,
   legend_title = "well_values",
-  FUN = function(metabarlist) {     rowSums(metabarlist$reads) },
+  FUN = function(metabarlist) {
+     rowSums(metabarlist$reads)
+ },
   taglist = as.character(unique(metabarlist$pcrs$tag_rev))
 )
 }


### PR DESCRIPTION
There are 'false' paths in tax_slv_ssu_138.1.txt:
Eukaryota;**Amorphea;Amoebozoa;**SAR;Stramenopiles;
Eukaryota;**Amorphea;Amoebozoa;**SAR;Stramenopiles;Labyrinthulomycetes;
Eukaryota;**Amorphea;Amoebozoa;**SAR;Stramenopiles;Labyrinthulomycetes;Sorodiplophrys;

They are corrected in this new version of silva_annotator.