### PR TITLE
update replicate names

### DIFF
--- a/R/pcrslayer.R
+++ b/R/pcrslayer.R
@@ -423,8 +423,8 @@ check_pcr_repl <- function(metabarlist,
       funcpcr <- ifelse(funcpcr, "0ok", "dyspcr")
 
       }
-
     reads_stdt <- reads/rowSums(reads)
+    replicates <- paste0("bar_", as.character(replicates))
     bar <- rowsum(reads_stdt, replicates)/as.vector(table(replicates))
     all <- rbind(reads_stdt, bar)
     all.d <- vegdist(all, "bray")


### PR DESCRIPTION
To avoid weird behavior of the check_pcrs_rpl function, more precisely during the detection of barycenters, I paste "bar_" at the beginning of each name of replicates. This trick make the code more robust again side effects of row names renaming by data.frame when sample name begin by digits.