### PR TITLE
Update aggregate_pcrs.R : avoid error while non-identical plates coor…

### DIFF
--- a/R/aggregate_pcrs.R
+++ b/R/aggregate_pcrs.R
@@ -81,7 +81,7 @@ aggregate_pcrs <- function(metabarlist,
         if (is.numeric(x)) {
           mean(x)
         } else {
-          ifelse(length(unique(x)) == 1, x[1], paste(unique(sort(x)), collapse = "|"))
+          ifelse(length(unique(x)) == 1, x[1], paste(unique(x), collapse = "|"))
         }
       })
     })))


### PR DESCRIPTION
…dinates

I suggest removing the sort() function in order to resolve the issue raised here https://github.com/metabaRfactory/metabaR/issues/55#issuecomment-3132836584 (two samples placed in different locations but forming identical combinations if these combinations are then sorted resolve the error). We will see if this addresses all situations.